### PR TITLE
Fix orm helpers

### DIFF
--- a/score/sa/orm/helpers.py
+++ b/score/sa/orm/helpers.py
@@ -22,7 +22,7 @@ def create_relationship_class(cls1, cls2, member, *, classname=None,
     following:
 
     >>> class UserGroup(Storable):
-    ...     __score_db__: {
+    ...     __score_sa_orm__: {
     ...         'inheritance': None
     ...     }
     ...     index = Column(Integer, nullable=False)
@@ -56,7 +56,7 @@ def create_relationship_class(cls1, cls2, member, *, classname=None,
     refcol1 = cls1.__tablename__[1:]
     refcol2 = cls2.__tablename__[1:]
     members = {
-        '__score_db__': {
+        '__score_sa_orm__': {
             'inheritance': None
         },
         idcol1: Column(
@@ -80,7 +80,7 @@ def create_relationship_class(cls1, cls2, member, *, classname=None,
         }
     if sorted:
         members['index'] = Column(Integer, nullable=False)
-    cls = type(classname, (cls1.__score_db__['base'],), members)
+    cls = type(classname, (cls1.__score_sa_orm__['base'],), members)
     if sorted:
         rel = relationship(cls2, secondary=cls.__tablename__,
                            order_by='%s.index' % cls.__name__,
@@ -122,7 +122,7 @@ def create_collection_class(owner, member, column, *,
     else:
         bref = backref(member + '_wrapper')
     members = {
-        '__score_db__': {
+        '__score_sa_orm__': {
             'inheritance': None
         },
         'owner_id': Column(IdType, ForeignKey('%s.id' % owner.__tablename__),
@@ -136,7 +136,7 @@ def create_collection_class(owner, member, column, *,
         members['__table_args__'] = (
             UniqueConstraint(members['owner_id'], column),
         )
-    cls = type(name, (owner.__score_db__['base'],), members)
+    cls = type(name, (owner.__score_sa_orm__['base'],), members)
     proxy = association_proxy(member + '_wrapper', 'value',
                               creator=lambda v: cls(value=v))
     setattr(owner, member, proxy)


### PR DESCRIPTION
The orm helpers were using the `__score_db__` attribute, which I assume was used in the deprecated `py.db` module. This lead to the helpers failing (just tested the `create_relationship_class` helper).

Tested using the following code:
```python
# Models

from score.sa.orm import create_base, create_relationship_class, IdType
from sqlalchemy import Column, String, Boolean, ForeignKey

Storable = create_base()


class User(Storable):
    id = Column(IdType, nullable=False, primary_key=True)
    name = Column(String, nullable=False)


class Blogger(User):
    may_publish = Column(Boolean, nullable=False, default=True)


class AdminUser(User):
    id = Column(IdType, ForeignKey('_user.id'),
                nullable=False, primary_key=True)


class Group(Storable):
    name = Column(String, nullable=False)


class Article(Storable):
    author_id = Column(IdType, ForeignKey('_user.id'), nullable=False)


UserGroup = create_relationship_class(
    User, Group, 'groups', sorted=False, duplicates=False, backref='users')
```

```python
# Execution

from score.init import init

from tmp.models import User, AdminUser, Group


config = {
    "score.init": {
        "modules": ["score.sa.db", "score.sa.orm"]
    },
    "db": {
        "sqlalchemy.url": "sqlite:////tmp/test_3.db",
        "destroyable": "True"
    },
    "orm": {
        "base": "tmp.models.Storable"
    }
}

app = init(config)
app.orm.create()
session = app.orm.Session()

admin = AdminUser(name="tom")
session.add(admin)
session.flush()
result = session.query(User).filter(User.id == admin.id).first()
assert isinstance(result, AdminUser)

user = User(name='Mousebender')
group = Group(name='Customer')
user.groups.append(group)
session.add(user)
session.add(group)
session.flush()

users = list(session.query(User))
groups = list(session.query(Group))
```